### PR TITLE
Login and password recovery tests

### DIFF
--- a/tests/features/fazer_login.feature
+++ b/tests/features/fazer_login.feature
@@ -1,0 +1,15 @@
+#language: pt
+
+Funcionalidade: fazer login
+    Para realizar um login
+    Sendo um usuário já cadastrado
+    Posso acessar as funcionalidades do site
+
+    Contexto: acessar o modal de login
+        Dado que o usuário acessa a tela de login
+    
+    Cenário: preencher as credenciais de acesso e enviar
+        Quando o usuário preencher as informações corretas de login
+        Então deve aparecer como usuário logado
+
+    

--- a/tests/features/recuperar_senha.feature
+++ b/tests/features/recuperar_senha.feature
@@ -1,0 +1,15 @@
+#language: pt
+
+Funcionalidade: recuperar senha
+    Para recuperar a senha
+    Sendo um usuário já cadastrado
+    Posso voltar a usar o login do site
+
+    Contexto: acessar o modal de recuperar a senha
+        Dado que o usuário acessa o modal de recuperar senha
+    
+    Cenário: preencher as credenciais de acesso e enviar
+        Quando o usuário preencher as informações de recuperação
+        Então deve receber um feedback positivo de recuperação
+
+    

--- a/tests/features/step_definitions/fazer_login.rb
+++ b/tests/features/step_definitions/fazer_login.rb
@@ -1,0 +1,17 @@
+Dado('que o usuário acessa a tela de login') do
+    visit 'https://cuidando.vc/2022/1'
+end
+
+Quando('o usuário preencher as informações corretas de login') do
+    page.find('a', text: 'Entrar').click
+    page.find('#modal-dialog')
+    page.find("#login-form-username").fill_in(with: 'NoneTest')
+    page.find("#login-form-password").fill_in(with: 'none1234')
+    click_button('Entrar')
+    sleep 5
+end
+
+Então('deve aparecer como usuário logado') do
+    visit 'https://cuidando.vc/pessoa/NoneTest'
+    expect(page).to have_button('Editar')
+end

--- a/tests/features/step_definitions/recuperar_senha.rb
+++ b/tests/features/step_definitions/recuperar_senha.rb
@@ -1,0 +1,17 @@
+Dado('que o usuário acessa o modal de recuperar senha') do
+    visit 'https://cuidando.vc/2022/1'
+    page.find('a', text: 'Entrar').click
+    page.find('#modal-dialog')
+    page.find('a', text: 'Esqueceu a senha?').click
+end
+
+Quando('o usuário preencher as informações de recuperação') do
+    page.find("#login-form-username").fill_in(with: 'NoneTest')
+    page.find("#login-form-email").fill_in(with: 'none20840@gmail.com')
+    click_button('Solicitar código')
+    sleep 5
+end
+
+Então('deve receber um feedback positivo de recuperação') do
+    expect(page).not_to have_text('E-mail errado.')
+end


### PR DESCRIPTION
### Description
Adding tests for both "login" and "password recovery" flows.
As the website does not provide a clear feedback for both scenarios, the expects about the flow are:

#### Login
Login, wait until request is done, and then visit the user page. There should be an "edit button", that only appear when user is logged.

#### Password Recovery
As this is a flow beyond the website (includes email verification)  the expect is that "no error message" appear on flow. In order to request password recovery users must add both username and email. If they do not match, then an error message appears on the screen.
